### PR TITLE
fixing typo in url for 'features' page

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,7 +40,7 @@ thousands of metrics. The daemon comes with [over
 cases to very specialized and advanced topics. It provides powerful networking
 features and is extensible in numerous ways. Last but not least: collectd is
 actively developed and supported and well documented. A more complete [list of
-features](features.shtml) is available in our wiki.
+features](features.html) is available in our wiki.
 
 ### Limitations
 


### PR DESCRIPTION
Very small fix for a very small bug. The "list of features" link on the main page has a typo in it (leads to "features.shtml" instead of "features.html"
![image](https://github.com/user-attachments/assets/b6ca6b58-08a7-419c-8458-1830edf73abe)
Clicking it leads to a 404 page.
![image](https://github.com/user-attachments/assets/d2ae0324-23b0-4b59-aa72-5942b09c0d0d)
